### PR TITLE
Fix wipe emoji (🪦→🥀) and rename !raid → !muster

### DIFF
--- a/_includes/archive.html
+++ b/_includes/archive.html
@@ -7,7 +7,7 @@
     </h2>
     <p class="archiveIntro">
       📜 The okra-patch&rsquo;s chronicle &mdash; every boss the patch has faced this season, newest first.<br/>
-      <small>*🌱 means the patch prevailed &middot; 🪦 means we&rsquo;ll get &rsquo;em next week</small>
+      <small>*🌱 means the patch prevailed &middot; 🥀 means we&rsquo;ll get &rsquo;em next week</small>
     </p>
     <div id="archiveSeason" class="archiveSeason" hidden></div>
     <div id="archiveBody" class="archiveBody">Reading the chronicles&hellip;</div>
@@ -74,7 +74,7 @@
   /* Pick the win/loss badge from result + boss.status (text, never color-only). */
   function badgeFor(res, boss){
     if(res.downed === true) return { cls: "downed", text: "🌱 DOWNED" };
-    if(boss.status === "wiped" || (res.status === "done" && res.downed === false)) return { cls: "wiped", text: "🪦 WIPED" };
+    if(boss.status === "wiped" || (res.status === "done" && res.downed === false)) return { cls: "wiped", text: "🥀 WIPED" };
     if(boss.status === "live") return { cls: "live", text: "⚔️ LIVE NOW" };
     return { cls: "pending", text: "⏳ UPCOMING" };
   }

--- a/_includes/arena.html
+++ b/_includes/arena.html
@@ -95,7 +95,7 @@
 
     const outcomeHtml = outcome
       ? '<div class="raidStatus ' + (outcome === "victory" ? "downed" : "wiped") + ' battleOutcome">' +
-          (outcome === "victory" ? "💀 VICTORY — " + esc(model.boss.name) + " falls! 🌱" : "🪦 DEFEAT — the patch is wiped.") + '</div>'
+          (outcome === "victory" ? "💀 VICTORY — " + esc(model.boss.name) + " falls! 🌱" : "🥀 DEFEAT — the patch is wiped.") + '</div>'
       : "";
 
     body.innerHTML =

--- a/_includes/leaderboard.html
+++ b/_includes/leaderboard.html
@@ -7,7 +7,7 @@
     </h2>
     <p class="lbIntro">
       🏆 The okra-patch&rsquo;s hardest hitters this season &mdash; every point of boss damage tallied.<br/>
-      <small>*sign up in chat with <code>!raid</code> &middot; damage is summed from each raid-night battle</small>
+      <small>*sign up in chat with <code>!muster</code> &middot; damage is summed from each raid-night battle</small>
     </p>
     <div id="lbSeason" class="lbSeason" hidden></div>
     <div id="lbBody" class="lbBody">Tallying the harvest&hellip;</div>
@@ -68,7 +68,7 @@
 
   function rowsHtml(entries){
     if(!entries.length){
-      return '<p class="lbEmpty">No damage logged yet this season — jump in with <code>!raid</code> in chat! 🌱</p>';
+      return '<p class="lbEmpty">No damage logged yet this season — jump in with <code>!muster</code> in chat! 🌱</p>';
     }
     const top = entries[0].damage || 1;
     const rank3 = ["🥇", "🥈", "🥉"];

--- a/_includes/raid.html
+++ b/_includes/raid.html
@@ -7,7 +7,7 @@
     </h2>
     <p class="raidIntro">
       🗡️ The whole okra-patch musters against one big bad. Chat while Nikki&rsquo;s live to grow your hero and gear up, then we field the team on raid night.<br/>
-      <small>*sign up in chat with <code>!raid</code> &middot; battle resolves automatically on the live page</small>
+      <small>*sign up in chat with <code>!muster</code> &middot; battle resolves automatically on the live page</small>
     </p>
     <div id="raidBody" class="raidBody">Summoning the boss&hellip;</div>
     <p id="raidNote" class="raidNote"></p>
@@ -95,7 +95,7 @@
 
   function rosterHtml(signups){
     const list = Object.values(signups || {});
-    if(!list.length) return '<p class="raidEmpty">No heroes signed up yet — type <code>!raid</code> in chat to muster! 🌱</p>';
+    if(!list.length) return '<p class="raidEmpty">No heroes signed up yet — type <code>!muster</code> in chat to muster! 🌱</p>';
     list.sort((a, b) => (b.roleRating || 0) - (a.roleRating || 0));
     return '<div class="roster">' + list.map((p) =>
       '<div class="rosterItem">' +
@@ -162,7 +162,7 @@
     // signup / locked
     const heading = phase === "locked"
       ? '<div class="raidPhaseTag locked">🔒 Roster locked — battle imminent</div>'
-      : '<div class="raidPhaseTag signup">📣 Muster open — sign up in chat with <code>!raid</code></div>';
+      : '<div class="raidPhaseTag signup">📣 Muster open — sign up in chat with <code>!muster</code></div>';
     raidBody.innerHTML = bossHead + heading +
       '<p class="cdCaption">Raid night begins in</p>' +
       countdownHtml(cfg.startsAt) +

--- a/_includes/raid.html
+++ b/_includes/raid.html
@@ -149,7 +149,7 @@
       const downed = res.downed;
       raidBody.innerHTML = bossHead +
         '<div class="raidStatus ' + (downed ? "downed" : "wiped") + '">' +
-          (downed ? "💀 BOSS DOWNED — the patch prevails! 🌱" : "🪦 WIPE — we&rsquo;ll get it next week.") + '</div>' +
+          (downed ? "💀 BOSS DOWNED — the patch prevails! 🌱" : "🥀 WIPE — we&rsquo;ll get it next week.") + '</div>' +
         (typeof res.bossHpRemaining === "number"
           ? '<p class="raidResultLine">Final boss HP: ' + num(res.bossHpRemaining) + ' / ' + num(boss.hp) + '</p>' : "") +
         '<a class="pollBtn liveCta" href="' + ARENA_URL + '">▶ WATCH THE REPLAY</a>' +

--- a/how-to-play.html
+++ b/how-to-play.html
@@ -45,7 +45,7 @@ noindex: true
       </li>
       <li class="htpStep">
         <span class="htpStepTitle">Muster the patch 📣</span>
-        <small>When the weekly boss is announced, a signup window opens. Subscribers type <code>!raid</code> to enlist your hero in this week&rsquo;s fight. The roster fills up live on the Muster page.</small>
+        <small>When the weekly boss is announced, a signup window opens. Subscribers type <code>!muster</code> to enlist your hero in this week&rsquo;s fight. The roster fills up live on the Muster page.</small>
       </li>
       <li class="htpStep">
         <span class="htpStepTitle">Raid night ⚔️</span>
@@ -89,7 +89,7 @@ noindex: true
         <div class="cmdDesc">Roll for the active loot drop while it&rsquo;s open. Your very first grab ever is guaranteed to land. 🌱</div>
       </li>
       <li class="cmdRow cmdSub">
-        <div class="cmdSyntax"><code>!raid</code> <span class="subTag">subs to muster</span></div>
+        <div class="cmdSyntax"><code>!muster</code> <span class="subTag">subs to muster</span></div>
         <div class="cmdDesc">During the signup window, enlist your hero for this week&rsquo;s raid (subscribers). Any time, it also reports the current raid status and links you to the action.</div>
       </li>
       <li class="cmdRow">
@@ -116,7 +116,7 @@ noindex: true
       <p class="htpFaqQ">I&rsquo;m subscribed but I&rsquo;m not gaining EXP — what gives?</p>
       <p class="htpFaqA">EXP only accrues while the stream is <strong>live</strong>. If the channel is offline, your messages won&rsquo;t feed your hero — pop back in once Nikki&rsquo;s live. 🌱</p>
       <p class="htpFaqQ">My sub lapsed. Did I lose my hero?</p>
-      <p class="htpFaqA">Nope! Your hero, level, and gear are all kept, and you keep earning EXP from chatting while live. You&rsquo;ll just need to re-sub to <strong>create a new hero</strong> or to <strong>muster for a raid</strong> with <code>!raid</code>.</p>
+      <p class="htpFaqA">Nope! Your hero, level, and gear are all kept, and you keep earning EXP from chatting while live. You&rsquo;ll just need to re-sub to <strong>create a new hero</strong> or to <strong>muster for a raid</strong> with <code>!muster</code>.</p>
     </div>
   </div>
 </section>


### PR DESCRIPTION
Follow-ups after the initial UI merge (#4).

- **Fix the wipe/defeat emoji** — `🪦` (U+1FAA6, Emoji 13.0) renders as a missing-glyph box on older systems/fonts. Swapped all wipe/defeat occurrences (arena banner, archive badge + legend, raid wipe) to `🥀` (wilted flower, Emoji 3.0) — universally supported and on-theme.
- **`!raid` → `!muster`** — updated the in-chat command hints on the muster, leaderboard, and how-to-play pages to match the bot's renamed command. URL paths (`/raid/`) unchanged.

🤖 Generated with [Claude Code](https://claude.com/claude-code)