### PR TITLE
How-to-play: loot is a single-winner drawing

### DIFF
--- a/how-to-play.html
+++ b/how-to-play.html
@@ -41,7 +41,7 @@ noindex: true
       </li>
       <li class="htpStep">
         <span class="htpStepTitle">Level up &amp; gear up ⚒️</span>
-        <small>Fill the EXP bar to level up and get stronger. When loot drops in chat, <code>!grab</code> it, then <code>!equip</code> the good stuff into your weapon, armor, and trinket slots.</small>
+        <small>Fill the EXP bar to level up and get stronger. When loot drops in chat, <code>!grab</code> to enter the draw, then <code>!equip</code> what you win into your weapon, armor, and trinket slots.</small>
       </li>
       <li class="htpStep">
         <span class="htpStepTitle">Muster the patch 📣</span>
@@ -86,7 +86,7 @@ noindex: true
       </li>
       <li class="cmdRow cmdSub">
         <div class="cmdSyntax"><code>!grab</code> <span class="subTag">subs</span> <span class="cmdAlias">also: !loot</span></div>
-        <div class="cmdDesc">Roll for the active loot drop while it&rsquo;s open. Your very first grab ever is guaranteed to land. 🌱</div>
+        <div class="cmdDesc">Enter the drawing for the active loot drop while the window&rsquo;s open. One winner is drawn when it closes — the item goes to them. 🎲</div>
       </li>
       <li class="cmdRow cmdSub">
         <div class="cmdSyntax"><code>!muster</code> <span class="subTag">subs to muster</span></div>
@@ -106,7 +106,7 @@ noindex: true
       <li><strong>EXP only grows while live.</strong> Your hero earns EXP from chatting <em>only</em> when the channel is actually live — off-stream messages don&rsquo;t count.</li>
       <li><strong>Leveling is steady, not lucky.</strong> Each level needs a fixed EXP bar to fill; once it&rsquo;s full, your level-up lands within a few guaranteed messages. There&rsquo;s no random jackpot and no bad-luck streak — fill the bar, get the level.</li>
       <li><strong>Higher sub tiers hit harder.</strong> A higher subscription tier boosts both how fast your hero earns EXP and its combat power on raid night.</li>
-      <li><strong>Loot grabs are tier-fair.</strong> When a drop is up, every subscriber tier has the exact same odds of grabbing it — no tier gets better loot luck than another.</li>
+      <li><strong>Loot is a fair draw.</strong> Every entrant — and every subscriber tier — has the exact same odds of winning the drawing; no tier gets better loot luck than another.</li>
     </ul>
   </div>
 


### PR DESCRIPTION
Companion to the backend loot-lottery change. Updates the how-to-play page so `!grab` is described as **entering a drawing** (one winner drawn at window close), removing the stale "first grab is guaranteed" and "odds of grabbing" wording.

🤖 Generated with [Claude Code](https://claude.com/claude-code)