### PR TITLE
Game nav on every game page (shared include)

### DIFF
--- a/_includes/archive.html
+++ b/_includes/archive.html
@@ -16,13 +16,7 @@
          currently always reads config/raid (the ACTIVE week); replaying an
          archived raid needs /arena/ to accept ?s=<seasonId>&w=<weekId> query
          params and load raids/<s>/<w>/combat for that specific week instead. -->
-    <nav class="gameNav" aria-label="Okra raid game pages">
-      <a class="gameNavLink" href="{{ '/raid/' | relative_url }}">🌱 Muster</a>
-      <a class="gameNavLink" href="{{ '/arena/' | relative_url }}">⚔️ Arena</a>
-      <a class="gameNavLink" href="{{ '/leaderboard/' | relative_url }}">🏆 Leaderboard</a>
-      <a class="gameNavLink" href="{{ '/archive/' | relative_url }}" aria-current="page">📜 Past Raids</a>
-      <a class="gameNavLink" href="{{ '/how-to-play/' | relative_url }}">📖 How to Play</a>
-    </nav>
+    {% include game-nav.html current="archive" %}
     <p id="archiveNote" class="gameNote"></p>
   </div>
 </section>

--- a/_includes/arena.html
+++ b/_includes/arena.html
@@ -12,6 +12,8 @@
     </div>
     <p id="battleNote" class="raidNote"></p>
   </div>
+
+  {% include game-nav.html current="arena" %}
 </section>
 
 <!-- ===== Live boss battle — READ-ONLY combat-log PLAYER =====

--- a/_includes/game-nav.html
+++ b/_includes/game-nav.html
@@ -1,0 +1,13 @@
+{%- comment -%}
+  Shared raid-game page nav. Used on every game surface so the links stay in sync.
+  Pass `current` to mark the active page:
+    {% include game-nav.html current="raid" %}
+  Valid values: raid | arena | leaderboard | archive | how-to-play (omit on the home page).
+{%- endcomment -%}
+<nav class="gameNav" aria-label="Okra raid game pages">
+  <a class="gameNavLink" href="{{ '/raid/' | relative_url }}"{% if include.current == 'raid' %} aria-current="page"{% endif %}>🌱 Muster</a>
+  <a class="gameNavLink" href="{{ '/arena/' | relative_url }}"{% if include.current == 'arena' %} aria-current="page"{% endif %}>⚔️ Arena</a>
+  <a class="gameNavLink" href="{{ '/leaderboard/' | relative_url }}"{% if include.current == 'leaderboard' %} aria-current="page"{% endif %}>🏆 Leaderboard</a>
+  <a class="gameNavLink" href="{{ '/archive/' | relative_url }}"{% if include.current == 'archive' %} aria-current="page"{% endif %}>📜 Past Raids</a>
+  <a class="gameNavLink" href="{{ '/how-to-play/' | relative_url }}"{% if include.current == 'how-to-play' %} aria-current="page"{% endif %}>📖 How to Play</a>
+</nav>

--- a/_includes/leaderboard.html
+++ b/_includes/leaderboard.html
@@ -12,13 +12,7 @@
     <div id="lbSeason" class="lbSeason" hidden></div>
     <div id="lbBody" class="lbBody">Tallying the harvest&hellip;</div>
 
-    <nav class="gameNav" aria-label="Okra raid game pages">
-      <a class="gameNavLink" href="{{ '/raid/' | relative_url }}">🌱 Muster</a>
-      <a class="gameNavLink" href="{{ '/arena/' | relative_url }}">⚔️ Arena</a>
-      <a class="gameNavLink" href="{{ '/leaderboard/' | relative_url }}" aria-current="page">🏆 Leaderboard</a>
-      <a class="gameNavLink" href="{{ '/archive/' | relative_url }}">📜 Past Raids</a>
-      <a class="gameNavLink" href="{{ '/how-to-play/' | relative_url }}">📖 How to Play</a>
-    </nav>
+    {% include game-nav.html current="leaderboard" %}
     <p id="lbNote" class="gameNote"></p>
   </div>
 </section>

--- a/_includes/raid.html
+++ b/_includes/raid.html
@@ -21,6 +21,8 @@
     </form>
     <div id="charBody" class="charBody">Enter your Twitch name to view your hero.</div>
   </div>
+
+  {% include game-nav.html current="raid" %}
 </section>
 
 <!-- ===== Weekly raid — staging page (READ-ONLY Firebase render) =====

--- a/how-to-play.html
+++ b/how-to-play.html
@@ -18,13 +18,7 @@ noindex: true
       <small>*all from chat while Nikki&rsquo;s live &middot; the battle plays out on the site</small>
     </p>
     <a class="pollBtn gameCta" href="{{ '/raid/' | relative_url }}">▶ ENTER THE RAID</a>
-    <nav class="gameNav" aria-label="Okra raid game pages">
-      <a class="gameNavLink" href="{{ '/raid/' | relative_url }}">🌱 Muster</a>
-      <a class="gameNavLink" href="{{ '/arena/' | relative_url }}">⚔️ Arena</a>
-      <a class="gameNavLink" href="{{ '/leaderboard/' | relative_url }}">🏆 Leaderboard</a>
-      <a class="gameNavLink" href="{{ '/archive/' | relative_url }}">📜 Past Raids</a>
-      <a class="gameNavLink" href="{{ '/how-to-play/' | relative_url }}" aria-current="page">📖 How to Play</a>
-    </nav>
+    {% include game-nav.html current="how-to-play" %}
   </div>
 
   <div class="htpPanel">

--- a/index.html
+++ b/index.html
@@ -23,13 +23,7 @@ title: OKRAFANS — Nikki BreAnne
     </h2>
     <p class="gameNavIntro">🗡️ Muster the okra-patch, field the team, and watch the boss fall — all from chat.</p>
     <a class="pollBtn gameCta" href="{{ '/raid/' | relative_url }}">▶ ENTER THE RAID</a>
-    <nav class="gameNav" aria-label="Okra raid game pages">
-      <a class="gameNavLink" href="{{ '/raid/' | relative_url }}">🌱 Muster</a>
-      <a class="gameNavLink" href="{{ '/arena/' | relative_url }}">⚔️ Arena</a>
-      <a class="gameNavLink" href="{{ '/leaderboard/' | relative_url }}">🏆 Leaderboard</a>
-      <a class="gameNavLink" href="{{ '/archive/' | relative_url }}">📜 Past Raids</a>
-      <a class="gameNavLink" href="{{ '/how-to-play/' | relative_url }}">📖 How to Play</a>
-    </nav>
+    {% include game-nav.html %}
   </div>
 </section>
 


### PR DESCRIPTION
Improves navigability between the raid-game pages.

**Before:** the game nav was on the home page, Leaderboard, Past Raids, and How-to-Play — but **not** on Muster (`/raid/`) or Arena (`/arena/`), so you couldn't jump between pages from those two.

**After:** every game surface renders the same nav (Muster · Arena · Leaderboard · Past Raids · How to Play) with the current page highlighted via `aria-current`.

Also DRYs it up: the link set was duplicated inline on four pages. It now lives in **one** file, `_includes/game-nav.html`, invoked with a `current` param — so adding/renaming a page later means editing one place, not six.

No styling or placement change to the existing pages (same `.gameNav` markup); just added it to Muster + Arena at the bottom of their panels.

🤖 Generated with [Claude Code](https://claude.com/claude-code)