### PR TITLE
Consistent game-nav footer (rendered from the layout)

### DIFF
--- a/_includes/archive.html
+++ b/_includes/archive.html
@@ -16,7 +16,6 @@
          currently always reads config/raid (the ACTIVE week); replaying an
          archived raid needs /arena/ to accept ?s=<seasonId>&w=<weekId> query
          params and load raids/<s>/<w>/combat for that specific week instead. -->
-    {% include game-nav.html current="archive" %}
     <p id="archiveNote" class="gameNote"></p>
   </div>
 </section>

--- a/_includes/arena.html
+++ b/_includes/arena.html
@@ -12,8 +12,6 @@
     </div>
     <p id="battleNote" class="raidNote"></p>
   </div>
-
-  {% include game-nav.html current="arena" %}
 </section>
 
 <!-- ===== Live boss battle — READ-ONLY combat-log PLAYER =====

--- a/_includes/leaderboard.html
+++ b/_includes/leaderboard.html
@@ -11,8 +11,6 @@
     </p>
     <div id="lbSeason" class="lbSeason" hidden></div>
     <div id="lbBody" class="lbBody">Tallying the harvest&hellip;</div>
-
-    {% include game-nav.html current="leaderboard" %}
     <p id="lbNote" class="gameNote"></p>
   </div>
 </section>

--- a/_includes/raid.html
+++ b/_includes/raid.html
@@ -21,8 +21,6 @@
     </form>
     <div id="charBody" class="charBody">Enter your Twitch name to view your hero.</div>
   </div>
-
-  {% include game-nav.html current="raid" %}
 </section>
 
 <!-- ===== Weekly raid — staging page (READ-ONLY Firebase render) =====

--- a/_layouts/default.html
+++ b/_layouts/default.html
@@ -30,6 +30,10 @@
     {{ content }}
   </main>
 
+  {% if page.game %}
+  <div class="gameFooterNav">{% include game-nav.html current=page.game %}</div>
+  {% endif %}
+
   <footer class="okraFooter">
     <div class="footerInner">
       <nav class="socials" aria-label="Nikki's socials">

--- a/archive.html
+++ b/archive.html
@@ -4,6 +4,7 @@ title: PAST RAIDS — OKRAFANS
 description: The chronicle of Nikki BreAnne's community raids — every boss the okra-patch has faced this season.
 permalink: /archive/
 noindex: true
+game: archive
 ---
 
 {% include archive.html %}

--- a/arena.html
+++ b/arena.html
@@ -4,6 +4,7 @@ title: THE ARENA — OKRAFANS
 description: Watch Nikki BreAnne's community raid battle play out, turn by turn.
 permalink: /arena/
 noindex: true
+game: arena
 ---
 
 {% include arena.html %}

--- a/assets/css/style.css
+++ b/assets/css/style.css
@@ -296,6 +296,9 @@ body {
 .gameNavLink:hover { background: #a6d96a; transform: scale(1.06); }
 .gameNavLink[aria-current="page"] { background: #2f4d18; color: #eaffd6; cursor: default; }
 .gameNote { font-size: 0.8em; color: #556; margin: 0.7em 0 0; min-height: 1em; }
+/* Game-page nav rendered once by the layout, as a consistent band just above the
+   site footer (see _layouts/default.html + _includes/game-nav.html). */
+.gameFooterNav { padding: 1.4em 1em 0.4em; text-align: center; }
 
 /* ---------- season leaderboard + past-raids archive (game) ---------- */
 .lbSection, .archiveSection { padding: 0.4em 1em; }

--- a/how-to-play.html
+++ b/how-to-play.html
@@ -4,6 +4,7 @@ title: HOW TO PLAY — OKRAFANS
 description: How the okra-patch raid game works — the weekly loop and every chat command for Nikki BreAnne's community raid.
 permalink: /how-to-play/
 noindex: true
+game: how-to-play
 ---
 
 <section class="htpSection">
@@ -18,7 +19,6 @@ noindex: true
       <small>*all from chat while Nikki&rsquo;s live &middot; the battle plays out on the site</small>
     </p>
     <a class="pollBtn gameCta" href="{{ '/raid/' | relative_url }}">▶ ENTER THE RAID</a>
-    {% include game-nav.html current="how-to-play" %}
   </div>
 
   <div class="htpPanel">

--- a/leaderboard.html
+++ b/leaderboard.html
@@ -4,6 +4,7 @@ title: SEASON LEADERBOARD — OKRAFANS
 description: The okra-patch's hardest-hitting heroes — Nikki BreAnne's community raid damage leaderboard.
 permalink: /leaderboard/
 noindex: true
+game: leaderboard
 ---
 
 {% include leaderboard.html %}

--- a/raid.html
+++ b/raid.html
@@ -4,6 +4,7 @@ title: THE WEEKLY RAID — OKRAFANS
 description: The okra-patch versus one big bad — Nikki BreAnne's chat-driven community raid.
 permalink: /raid/
 noindex: true
+game: raid
 ---
 
 {% include raid.html %}


### PR DESCRIPTION
Fixes the inconsistent nav placement from the previous change.

**Problem:** the game nav landed in a different position/context on each page — bottom on a bare background (Muster, Arena), inside the panel card (Leaderboard, Past Raids), and at the top (How-to-Play). Looked broken.

**Fix:** render it **once, from `_layouts/default.html`**, as a consistent `.gameFooterNav` band just above the site footer — on any page that sets `game: <name>` in its front-matter (current page highlighted via `aria-current`). The five game pages are flagged; the home keeps its landing card. Removed the five inline includes, so there's one source of truth and one place it renders.

Verified the markup structure (nav appears exactly once per game page; no inline navs remain). I can't run Jekyll in my env, so worth a quick look once it builds — but it's now structurally consistent by construction.

🤖 Generated with [Claude Code](https://claude.com/claude-code)