### PR TITLE
Docs: loot claim is !loot (alias !claim), not !grab

### DIFF
--- a/_data/commands.yml
+++ b/_data/commands.yml
@@ -26,8 +26,8 @@
 - group: "Loot & raids"
   blurb: "Chat loot drops, the weekly boss, and the leaderboard."
   commands:
-    - cmd: "!grab"
-      aliases: "!loot"
+    - cmd: "!loot"
+      aliases: "!claim"
       sub: true
       desc: "Enter the drawing for the active loot drop. One winner is drawn when the window closes and gets the item. 🎲"
     - cmd: "!muster"

--- a/how-to-play.html
+++ b/how-to-play.html
@@ -35,7 +35,7 @@ game: how-to-play
       </li>
       <li class="htpStep">
         <span class="htpStepTitle">Level up &amp; gear up ⚒️</span>
-        <small>Fill the EXP bar to level up and get stronger. When loot drops in chat, <code>!grab</code> to enter the draw, then <code>!equip</code> what you win into your weapon, armor, and trinket slots.</small>
+        <small>Fill the EXP bar to level up and get stronger. When loot drops in chat, <code>!loot</code> to enter the draw, then <code>!equip</code> what you win into your weapon, armor, and trinket slots.</small>
       </li>
       <li class="htpStep">
         <span class="htpStepTitle">Muster the patch 📣</span>
@@ -79,7 +79,7 @@ game: how-to-play
         <div class="cmdDesc">Bare a slot (weapon / armor / trinket) or a named item — it goes back into your bag.</div>
       </li>
       <li class="cmdRow cmdSub">
-        <div class="cmdSyntax"><code>!grab</code> <span class="subTag">subs</span> <span class="cmdAlias">also: !loot</span></div>
+        <div class="cmdSyntax"><code>!loot</code> <span class="subTag">subs</span> <span class="cmdAlias">also: !claim</span></div>
         <div class="cmdDesc">Enter the drawing for the active loot drop while the window&rsquo;s open. One winner is drawn when it closes — the item goes to them. 🎲</div>
       </li>
       <li class="cmdRow cmdSub">


### PR DESCRIPTION
Mirrors kennyBot PR #19: the loot claim is now **`!loot`** (alias **`!claim`**), not `!grab` — kennyBot dropped `!grab` because it collides with the quote/points bots common in Twitch chat.

Updates:
- `/commands/` reference: `!grab` → `!loot`, alias `!claim`.
- `/how-to-play/`: both `!grab` mentions → `!loot`.

Site builds clean; `!grab` no longer appears on either page.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
