### PR TITLE
Docs: add !duel to the command reference

### DIFF
--- a/_data/commands.yml
+++ b/_data/commands.yml
@@ -54,6 +54,9 @@
     - cmd: "!market suggest"
       args: "<question>"
       desc: "Propose a YES/NO market — e.g. <code>!market suggest Will we clear the boss tonight?</code>. A mod reviews it before it goes live."
+    - cmd: "!duel"
+      args: "<@user> <amount>"
+      desc: "Challenge another viewer to a coin-flip duel for credits. They reply <code>!duel accept</code> or <code>!duel deny</code>; on accept both stake the wager and the winner takes the whole pot. Expires in 3 minutes."
 
 - group: "Facts & meta"
   commands:


### PR DESCRIPTION
Documents kennyBot's new **`!duel`** command (companion to the kennyBot PR) in the `/commands/` reference, under Credits & the OKRAMARKET.

`!duel <@user> <amount>` — challenge a viewer to a coin-flip credit duel; they `!duel accept` / `!duel deny`; winner takes the whole pot; expires in 3 minutes.

Site builds clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
